### PR TITLE
Fix windows path issue

### DIFF
--- a/src/main/js/template.js
+++ b/src/main/js/template.js
@@ -30,7 +30,7 @@ var instrument = function (sources, tmp) {
 	var instrumenter = new istanbul.Instrumenter();
 	var instrumentedSources = [];
 	sources.forEach(function (source) {
-		var filteredSourcePath = (process.platform === 'win32')? source.replace(/^([a-z]):\//i, '$1/') : source, // do this for Windows
+		var filteredSourcePath = (process.platform === 'win32')? source.replace(/^([a-z]):\//i, '$1/') : source, // OS platform check so that we don't try to write "C:" as part of a folder name on Windows
 			tmpSource = path.join(tmp, filteredSourcePath);
 
 		grunt.file.write(


### PR DESCRIPTION
Hi there,

I'd like to submit a change for the instrument() function.

Currently, when the instrumented js files are copied to the grunt folder, there's an issue for developers running Windows.
Basically, the file paths looks like this: "c:/some/folder/source.js".

The colon character is invalid on Windows so I've made a quick change to remove it from the file path.

Feel free to let me know what you think.

Regards,

David
