### PR TITLE
Support baseDir and instrumentFiles options

### DIFF
--- a/src/main/js/template.js
+++ b/src/main/js/template.js
@@ -21,27 +21,36 @@ var DEFAULT_TEMPLATE = __dirname + '/../../../../grunt-contrib-jasmine/tasks/'
  * @private
  * @method instrument
  *
- * @param {Array} sources The paths of the original sources
+ * @param {Array} sources The paths of the original sources that need to be copied
+ * @param {Array} filesToInstrument The paths of the original sources that should be instrumented for code coverage
  * @param {String} tmp The path to the temporary directory
  *
- * @return {Array} The paths to the instrumented sources
+ * @return {Array} The paths to the copied sources
  */
-var instrument = function (sources, tmp) {
+var instrument = function (sources, filesToInstrument, tmp) {
 	var instrumenter = new istanbul.Instrumenter();
-	var instrumentedSources = [];
+	var newSourceFiles = [];
 	sources.forEach(function (source) {
-		var sanitizedSource = source;
+		var sanitizedSource = source,
+		    shouldInstrument = grunt.util._.include(filesToInstrument, source);
+
 		// don't try to write "C:" as part of a folder name on Windows
 		if (process.platform == 'win32') {
 			sanitizedSource = source.replace(/^([a-z]):/i, '$1');
 		}
 		var tmpSource = path.join(tmp, sanitizedSource);
-		grunt.file.write(tmpSource, instrumenter.instrumentSync(
-				grunt.file.read(source), source));
-		instrumentedSources.push(tmpSource);
+
+		var fileContents = grunt.file.read(source);
+		if(shouldInstrument){
+			fileContents = instrumenter.instrumentSync(fileContents, source);
+			newSourceFiles.push(tmpSource);
+		}
+
+		grunt.file.write(tmpSource, fileContents);
 	});
-	return instrumentedSources;
+	return newSourceFiles;
 };
+
 
 /**
  * Writes the coverage file.
@@ -172,8 +181,17 @@ exports.process = function (grunt, task, context) {
 	var tmpReporter = path.join(context.temp, TMP_REPORTER);
 	grunt.file.copy(REPORTER, tmpReporter);
 	context.scripts.reporters.unshift(tmpReporter);
+
+	// expand filesToInstrument option or assume we're instrumenting all sources
+	var filesToInstrument;
+	if(context.options.instrumentFiles){
+		filesToInstrument = grunt.file.expand(context.options.instrumentFiles);
+	} else {
+		filesToInstrument = context.scripts.src;
+	}
+
 	// instrument sources
-	var instrumentedSources = instrument(context.scripts.src, context.temp);
+	instrumentedSources = instrument(context.scripts.src, filesToInstrument, context.temp);
 
 	// clean up paths to src files when baseDir is set
 	if(context.options.baseDir){


### PR DESCRIPTION
This pull adds the `baseDir` and `instrumentFiles` options.

`baseDir` indicates the base directory that the JS will be served out of. This is useful when the JS files are found in a directory hierarchy on the file-system that doesn't match 1:1 with how the files are being served through connect.

`instrumentFiles` is a set of files (or file globs that grunt knows how to expand). When used these files will be the only ones that code coverage will be performed against.

The example configuration (from a Gruntfile) below shows how this works:

```
connect: {
  server: {
    options: {
      port: 8000,
      base: 'site/'
    }
  },
},
jasmine: {
  coverage: {
    src: 'site/js/**/*.js',
    options: {
      templateOptions: {
        template: require('grunt-template-jasmine-requirejs'),
        coverage: 'coverage/coverage.json',
        report: 'coverage',
        instrumentFiles: ['site/js/**/*.js', '!site/js/vendor/**/*.js'],
        baseDir: 'site/',
        templateOptions: {
          requireConfigFile: 'site/js/app/core/config.js',
          requireConfig: {
            baseUrl: '.grunt/grunt-contrib-jasmine/site/js'
          }
        }
      },

      // Setting +replace+ to false ensures that grunt-template-jasmine-istanbul
      // will leave alone the path to the files in the generated +outfile+. If this
      // is set to true then the +outfile+ will contain bad references to files that
      // requireJS tries to load.
      replace: false
    }
  }
}
```

The source files are found in the `site/` directory on the file-system but the connect server servers up `site/` as root so it's not necessary to keep `site/` in the generated src paths when the requireJS config gets read in, modified, and then written back out.

And in the above configuration all JS files in the `site/js/vendor/` directory will be excluding from the code coverage report.
