### PR TITLE
Prevent backslashes issues on Windows

### DIFF
--- a/src/main/js/template.js
+++ b/src/main/js/template.js
@@ -170,6 +170,10 @@ var processMixedInTemplate = function (grunt, task, context) {
 exports.process = function (grunt, task, context) {
 	// prepend coverage reporter
 	var tmpReporter = path.join(context.temp, TMP_REPORTER);
+	// prevent backslashes issues on Windows
+	if ( process.platform == 'win32' ) {
+		tmpReporter = context.temp + '/' + TMP_REPORTER;
+	}
 	grunt.file.copy(REPORTER, tmpReporter);
 	context.scripts.reporters.unshift(tmpReporter);
 	// instrument sources


### PR DESCRIPTION
Hello,

I got an issue on Windows, the result of the `path.join()` was `'.grunt\\grunt-contrib-jasmine\\grunt-template-jasmine-istanbul\\reporter.js'`.

Using it with **grunt-template-jasmine-require** it fails with the following error:

```
>> Error: scripterror: Illegal path or script error: 
['.gruntgrunt-contrib-jasminegrunt-template-jasmine-istanbulreporter.js']
```

This little hotfix will do the job properly (it works \o/).
