### PR TITLE
Make template compatible with Windows file separator

### DIFF
--- a/src/main/js/template.js
+++ b/src/main/js/template.js
@@ -169,7 +169,7 @@ var processMixedInTemplate = function (grunt, task, context) {
  */
 exports.process = function (grunt, task, context) {
 	// prepend coverage reporter
-	var tmpReporter = path.join(context.temp, TMP_REPORTER);
+	var tmpReporter = context.temp +  '/' + TMP_REPORTER;
 	grunt.file.copy(REPORTER, tmpReporter);
 	context.scripts.reporters.unshift(tmpReporter);
 	// instrument sources


### PR DESCRIPTION
When in Windows, I got

require([..., '.grunt/grunt-contrib-jasmine\grunt-template-jasmine-istanbul/reporter.js','.grunt\grunt-contrib-jasmine/reporter.js'])

And it is caused by Windows file separator in path.join().

After this change, it works in Windows.
