### PR TITLE
fix(test): #shouldInstrumentSource

### DIFF
--- a/src/test/js/template.js
+++ b/src/test/js/template.js
@@ -190,8 +190,9 @@ exports['template'] = {
 					'should store instrumented in temp directory');
 			var instrumented = this.context.scripts.src[0];
 			var found = grunt.file.read(instrumented).split('\n')[0];
-			var expected = 'if (typeof __coverage__ === \'undefined\') '
-					+ '{ __coverage__ = {}; }';
+
+			var expected = 'if (typeof __coverage__ === \'undefined\') '+
+					'{ __coverage__ = {}; }';
 			test.equal(found, expected, 'should be instrumented');
 			test.done();
 		},

--- a/src/test/js/template.js
+++ b/src/test/js/template.js
@@ -189,10 +189,10 @@ exports['template'] = {
 					path.join(TEMP, SRC),
 					'should store instrumented in temp directory');
 			var instrumented = this.context.scripts.src[0];
-			var found = grunt.file.read(instrumented).split('\n')[0];
+			var found = grunt.file.read(instrumented).split('\n')[1];
 
-			var expected = 'if (typeof __coverage__ === \'undefined\') '+
-					'{ __coverage__ = {}; }';
+			var expected = "var __cov_IWp9qM1GTBo1x3ZChf8cEQ = (Function('return this'))();";
+
 			test.equal(found, expected, 'should be instrumented');
 			test.done();
 		},


### PR DESCRIPTION
Fix test `#shouldInstrumentSource` which fails on lastest master [(d2212fb)](d2212fb) by updating `actual` and `expected` values.

`$ grunt test` is :green_heart: 

Maybe you want to have a look.

regards
~david