### PR TITLE
Don't throw error in reporter if coverage was not run

### DIFF
--- a/src/main/js/reporter.js
+++ b/src/main/js/reporter.js
@@ -14,7 +14,7 @@
 		 * @method jasmineDone
 		 */
 		jasmineDone: function () {
-			if (__coverage__) {
+			if (typeof __coverage__ !== 'undefined' && __coverage__) {
 				phantom.sendMessage('jasmine.coverage', __coverage__);
 			}
 		}

--- a/src/test/js/reporter.js
+++ b/src/test/js/reporter.js
@@ -79,7 +79,7 @@ exports['reporter'] = {
 	},
 	'shouldNotSendMessageToPhantom': function (test) {
 		var oldCoverage = __coverage__;
-		__coverage__ = null;
+		delete __coverage__;
 		var reporter = jasmine.reporters[0];
 		reporter.jasmineDone();
 		test.strictEqual(phantom.messages.length, 0, 'should not send message');


### PR DESCRIPTION
If tests weren't run with instrumented code, `__coverage__` never gets
defined in the global space. The previous check would throw
`Uncaught ReferenceError: __coverage__ is not defined`. I've updated
the check for determining whether or not to send the coverage command
to phantom to account for the case where `__coverage__` is not defined.