### PR TITLE
Modified template.js to copy reporter.js to the correct path.

### DIFF
--- a/src/main/js/template.js
+++ b/src/main/js/template.js
@@ -181,10 +181,10 @@ var processMixedInTemplate = function (grunt, task, context) {
 exports.process = function (grunt, task, context) {
 	var outputDirectory = path.dirname(context.outfile);
 	// prepend coverage reporter
-	var tmpReporter = path.relative(outputDirectory, path.join(context.temp,
-			TMP_REPORTER));
+	var tmpReporter = path.join(context.temp, TMP_REPORTER);
 	grunt.file.copy(REPORTER, tmpReporter);
-	context.scripts.reporters.unshift(getUri(tmpReporter));
+	context.scripts.reporters.unshift(getUri(path.relative(outputDirectory,
+		tmpReporter)));
 	// instrument sources
 	var files = context.options.files || '**/*';
 	var replacements = [];


### PR DESCRIPTION
fixes #31 :

If Jasmine's `options.outfile` is changed then coverage doesn't run.
The `SpecRunner` template seems to be generated correctly, but `grunt-template-jasmine-istanbul/reporter.js` is not being copied into the `.grunt/grunt-contrib-jasmine` directory.

This commit modifies the exports.process method of `template.js` in order to use the original path when copying `reporter.js`.