### PR TITLE
Remove install dependent path resolution

### DIFF
--- a/src/main/js/reporter.js
+++ b/src/main/js/reporter.js
@@ -7,12 +7,12 @@
  */
 (function () {
 	var reporter = {
-		/**
-		 * Reports the coverage variable by dispatching a message from phantom.
-		 *
-		 * @method jasmineDone
-		 * @return {void}
-		 */
+/**
+ * Reports the coverage variable by dispatching a message from phantom.
+ *
+ * @method jasmineDone
+ * @return {void}
+ */
 		jasmineDone: function () {
 			if (typeof __coverage__ !== 'undefined' && __coverage__) {
 				phantom.sendMessage('jasmine.coverage', __coverage__);

--- a/src/main/js/template.js
+++ b/src/main/js/template.js
@@ -11,7 +11,7 @@ var lodashTemplate = require('lodash.template');
 
 var REPORTER = __dirname + '/reporter.js';
 var TMP_REPORTER = 'grunt-template-jasmine-istanbul/reporter.js';
-var DEFAULT_TEMPLATE = require.resolve( 'grunt-contrib-jasmine/tasks/jasmine/templates/DefaultRunner.tmpl' );
+var DEFAULT_TEMPLATE = require.resolve('grunt-contrib-jasmine/tasks/jasmine/templates/DefaultRunner.tmpl');
 
 /**
  * Gets an URI from a file path. Accounts for Windows paths.

--- a/src/main/js/template.js
+++ b/src/main/js/template.js
@@ -11,8 +11,7 @@ var lodashTemplate = require('lodash.template');
 
 var REPORTER = __dirname + '/reporter.js';
 var TMP_REPORTER = 'grunt-template-jasmine-istanbul/reporter.js';
-var DEFAULT_TEMPLATE = __dirname + '/../../../../grunt-contrib-jasmine/tasks/'
-		+ 'jasmine/templates/DefaultRunner.tmpl';
+var DEFAULT_TEMPLATE = require.resolve( 'grunt-contrib-jasmine/tasks/jasmine/templates/DefaultRunner.tmpl' );
 
 /**
  * Gets an URI from a file path. Accounts for Windows paths.


### PR DESCRIPTION
Removed install dependent path resolution. The assumption of the package structure limits the usage of this module to only vanilla node.js when it doesn't have to. By using dynamic resolution other structures may be utilized as well as allowing for the default structure to change without breaking implementation.